### PR TITLE
Downgrade Go version to 1.23 in backend Dockerfile

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Updates backend Dockerfile to use Go 1.23 instead of 1.24 for compatibility.