### PR TITLE
Setup complete staging environment with full isolation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,22 @@
-name: Deploy Infrastructure with Terraform
+name: Reusable Deploy Workflow
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'terraform/**'
-      - 'apps/backend/**'
-      - 'apps/billing/**'
-      - '.github/workflows/terraform-deploy.yml'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'terraform/**'
-      - 'apps/backend/**'
-      - 'apps/billing/**'
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+        description: 'Environment to deploy to (production or staging)'
+      service_suffix:
+        required: false
+        type: string
+        default: ''
+        description: 'Suffix for service names (e.g., -staging)'
+      terraform_workspace:
+        required: false
+        type: string
+        default: 'default'
+        description: 'Terraform workspace to use'
 
 env:
   TF_VERSION: '1.5.0'
@@ -23,9 +25,10 @@ env:
 
 jobs:
   terraform-plan:
-    name: Terraform Plan
+    name: Terraform Plan (${{ inputs.environment }})
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    environment: ${{ inputs.environment }}
     
     steps:
     - name: Checkout
@@ -49,7 +52,13 @@ jobs:
       run: |
         terraform init \
           -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-          -backend-config="prefix=simple-relay"
+          -backend-config="prefix=simple-relay-${{ inputs.environment }}"
+
+    - name: Terraform Workspace
+      working-directory: ./terraform
+      if: inputs.terraform_workspace != 'default'
+      run: |
+        terraform workspace select ${{ inputs.terraform_workspace }} || terraform workspace new ${{ inputs.terraform_workspace }}
 
     - name: Terraform Validate
       working-directory: ./terraform
@@ -61,15 +70,21 @@ jobs:
         TF_VAR_api_base_url: ${{ secrets.API_BASE_URL }}
         TF_VAR_official_base_url: ${{ secrets.OFFICIAL_BASE_URL }}
         TF_VAR_image_tag: ${{ github.sha }}
-        TF_VAR_service_name: ${{ vars.SERVICE_NAME }}
+        TF_VAR_service_name: ${{ vars.SERVICE_NAME }}${{ inputs.service_suffix }}
+        TF_VAR_billing_service_name: ${{ vars.SERVICE_NAME }}-billing${{ inputs.service_suffix }}
+        TF_VAR_firestore_database_name: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
         TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
         TF_VAR_client_secret_key: ${{ secrets.ALLOWED_CLIENT_SECRET_KEY }}
       run: terraform plan -no-color
 
   terraform-deploy:
-    name: Deploy to Production
+    name: Deploy to ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    environment: ${{ inputs.environment }}
+    concurrency: 
+      group: deploy-${{ inputs.environment }}
+      cancel-in-progress: false
     
     steps:
     - name: Checkout
@@ -99,21 +114,27 @@ jobs:
     - name: Build and Push Backend Container
       working-directory: ./apps/backend
       run: |-
-        docker build -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-relay:${{ github.sha }}" ./
-        docker push "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-relay:${{ github.sha }}"
+        docker build -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-relay${{ inputs.service_suffix }}:${{ github.sha }}" ./
+        docker push "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-relay${{ inputs.service_suffix }}:${{ github.sha }}"
 
     - name: Build and Push Billing Container
       working-directory: ./apps/billing
       run: |-
-        docker build -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-billing:${{ github.sha }}" ./
-        docker push "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-billing:${{ github.sha }}"
+        docker build -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-billing${{ inputs.service_suffix }}:${{ github.sha }}" ./
+        docker push "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-billing${{ inputs.service_suffix }}:${{ github.sha }}"
 
     - name: Terraform Init
       working-directory: ./terraform
       run: |
         terraform init \
           -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-          -backend-config="prefix=simple-relay"
+          -backend-config="prefix=simple-relay-${{ inputs.environment }}"
+
+    - name: Terraform Workspace
+      working-directory: ./terraform
+      if: inputs.terraform_workspace != 'default'
+      run: |
+        terraform workspace select ${{ inputs.terraform_workspace }} || terraform workspace new ${{ inputs.terraform_workspace }}
 
     - name: Terraform Apply
       working-directory: ./terraform
@@ -121,7 +142,9 @@ jobs:
         TF_VAR_api_base_url: ${{ secrets.API_BASE_URL }}
         TF_VAR_official_base_url: ${{ secrets.OFFICIAL_BASE_URL }}
         TF_VAR_image_tag: ${{ github.sha }}
-        TF_VAR_service_name: ${{ vars.SERVICE_NAME }}
+        TF_VAR_service_name: ${{ vars.SERVICE_NAME }}${{ inputs.service_suffix }}
+        TF_VAR_billing_service_name: ${{ vars.SERVICE_NAME }}-billing${{ inputs.service_suffix }}
+        TF_VAR_firestore_database_name: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
         TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
         TF_VAR_client_secret_key: ${{ secrets.ALLOWED_CLIENT_SECRET_KEY }}
       run: terraform apply -auto-approve -no-color
@@ -129,4 +152,4 @@ jobs:
     - name: Get Service URL
       working-directory: ./terraform
       run: |
-        echo "Service deployed at: $(terraform output -raw service_url)"
+        echo "${{ inputs.environment }} service deployed at: $(terraform output -raw service_url)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   terraform-plan:
-    name: Terraform Plan (${{ inputs.environment }})
+    name: Terraform Plan
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     environment: ${{ inputs.environment }}
@@ -78,7 +78,7 @@ jobs:
       run: terraform plan -no-color
 
   terraform-deploy:
-    name: Deploy to ${{ inputs.environment }}
+    name: Deploy
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
         TF_VAR_firestore_database_name: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
         TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
         TF_VAR_client_secret_key: ${{ secrets.ALLOWED_CLIENT_SECRET_KEY }}
-      run: terraform plan -no-color
+      run: terraform plan -input=false -no-color
 
   terraform-deploy:
     name: Deploy
@@ -147,7 +147,7 @@ jobs:
         TF_VAR_firestore_database_name: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
         TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
         TF_VAR_client_secret_key: ${{ secrets.ALLOWED_CLIENT_SECRET_KEY }}
-      run: terraform apply -auto-approve -no-color
+      run: terraform apply -input=false -auto-approve -no-color
 
     - name: Get Service URL
       working-directory: ./terraform

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,26 @@
+name: Production
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'terraform/**'
+      - 'apps/backend/**'
+      - 'apps/billing/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'terraform/**'
+      - 'apps/backend/**'
+      - 'apps/billing/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
+      service_suffix: ''
+      terraform_workspace: default
+    secrets: inherit

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,26 @@
+name: Staging
+
+on:
+  push:
+    branches: [ staging ]
+    paths:
+      - 'terraform/**'
+      - 'apps/backend/**'
+      - 'apps/billing/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ staging ]
+    paths:
+      - 'terraform/**'
+      - 'apps/backend/**'
+      - 'apps/billing/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: staging
+      service_suffix: -staging
+      terraform_workspace: staging
+    secrets: inherit

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -70,6 +70,7 @@ type Config struct {
 	OfficialTarget           *url.URL
 	BillingServiceURL        string
 	ProjectID                string
+	DatabaseName             string
 }
 
 func loadConfig() *Config {
@@ -111,12 +112,18 @@ func loadConfig() *Config {
 		log.Fatal("GCP_PROJECT_ID environment variable is required")
 	}
 
+	databaseName := os.Getenv("FIRESTORE_DATABASE_NAME")
+	if databaseName == "" {
+		log.Fatal("FIRESTORE_DATABASE_NAME environment variable is required")
+	}
+
 	return &Config{
 		APIKey:                   apiKey,
 		AllowedClientSecretKey:   allowedClientSecretKey,
 		OfficialTarget:           officialTarget,
 		BillingServiceURL:        billingServiceURL,
 		ProjectID:                projectID,
+		DatabaseName:             databaseName,
 	}
 }
 
@@ -124,7 +131,7 @@ func main() {
 	config := loadConfig()
 	
 	// Initialize database service for OAuth
-	dbService, err := services.NewDatabaseService(config.ProjectID)
+	dbService, err := services.NewDatabaseServiceWithDatabase(config.ProjectID, config.DatabaseName)
 	if err != nil {
 		log.Fatalf("Failed to initialize database service: %v", err)
 	}

--- a/apps/backend/internal/services/database.go
+++ b/apps/backend/internal/services/database.go
@@ -12,13 +12,19 @@ type DatabaseService struct {
 }
 
 type DatabaseConfig struct {
-	ProjectID string
+	ProjectID    string
+	DatabaseName string
 }
 
-func NewDatabaseService(projectID string) (*DatabaseService, error) {
+func NewDatabaseServiceWithDatabase(projectID, databaseName string) (*DatabaseService, error) {
 	ctx := context.Background()
 	
-	client, err := firestore.NewClient(ctx, projectID)
+	var client *firestore.Client
+	var err error
+	
+	// Always use named database - no more implicit defaults
+	client, err = firestore.NewClientWithDatabase(ctx, projectID, databaseName)
+	
 	if err != nil {
 		return nil, fmt.Errorf("firestore.NewClient: %w", err)
 	}

--- a/apps/billing/cmd/main.go
+++ b/apps/billing/cmd/main.go
@@ -12,8 +12,10 @@ import (
 	"github.com/joho/godotenv"
 )
 
+
 type Config struct {
 	ProjectID      string
+	DatabaseName   string
 	BillingEnabled bool
 }
 
@@ -27,10 +29,16 @@ func loadConfig() *Config {
 		log.Fatal("GCP_PROJECT_ID environment variable is required")
 	}
 
+	databaseName := os.Getenv("FIRESTORE_DATABASE_NAME")
+	if databaseName == "" {
+		log.Fatal("FIRESTORE_DATABASE_NAME environment variable is required")
+	}
+
 	billingEnabled := os.Getenv("BILLING_ENABLED") == "true"
 
 	return &Config{
 		ProjectID:      projectID,
+		DatabaseName:   databaseName,
 		BillingEnabled: billingEnabled,
 	}
 }
@@ -39,7 +47,7 @@ func main() {
 	config := loadConfig()
 
 	// Initialize database service
-	dbService, err := services.NewDatabaseService(config.ProjectID)
+	dbService, err := services.NewDatabaseServiceWithDatabase(config.ProjectID, config.DatabaseName)
 	if err != nil {
 		log.Fatalf("Failed to initialize database service: %v", err)
 	}

--- a/apps/billing/internal/services/database.go
+++ b/apps/billing/internal/services/database.go
@@ -12,13 +12,19 @@ type DatabaseService struct {
 }
 
 type DatabaseConfig struct {
-	ProjectID string
+	ProjectID    string
+	DatabaseName string
 }
 
-func NewDatabaseService(projectID string) (*DatabaseService, error) {
+func NewDatabaseServiceWithDatabase(projectID, databaseName string) (*DatabaseService, error) {
 	ctx := context.Background()
 	
-	client, err := firestore.NewClient(ctx, projectID)
+	var client *firestore.Client
+	var err error
+	
+	// Always use named database - no more implicit defaults
+	client, err = firestore.NewClientWithDatabase(ctx, projectID, databaseName)
+	
 	if err != nil {
 		return nil, fmt.Errorf("firestore.NewClient: %w", err)
 	}

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -6,7 +6,8 @@ resource "google_project_service" "required_apis" {
     "run.googleapis.com",
     "compute.googleapis.com",
     "servicenetworking.googleapis.com",
-    "cloudbuild.googleapis.com"
+    "cloudbuild.googleapis.com",
+    "artifactregistry.googleapis.com"
   ])
   
   service            = each.value

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -1,0 +1,9 @@
+# Artifact Registry repository for Docker images
+resource "google_artifact_registry_repository" "simple_relay" {
+  location      = var.region
+  repository_id = "simple-relay"
+  description   = "Docker repository for Simple Relay application"
+  format        = "DOCKER"
+  
+  depends_on = [google_project_service.required_apis]
+}

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -63,6 +63,11 @@ resource "google_cloud_run_v2_service" "simple_relay" {
         name  = "GCP_PROJECT_ID"
         value = var.project_id
       }
+      
+      env {
+        name  = "FIRESTORE_DATABASE_NAME"
+        value = var.firestore_database_name
+      }
 
       # Secrets from Secret Manager
       env {
@@ -163,7 +168,7 @@ resource "google_cloud_run_v2_service" "simple_billing" {
     }
 
     containers {
-      image = "us-central1-docker.pkg.dev/${var.project_id}/${var.service_name}/simple-billing:${var.image_tag}"
+      image = "us-central1-docker.pkg.dev/${var.project_id}/simple-relay/${var.billing_service_name}:${var.image_tag}"
 
       env {
         name  = "BILLING_ENABLED"
@@ -173,6 +178,11 @@ resource "google_cloud_run_v2_service" "simple_billing" {
       env {
         name  = "GCP_PROJECT_ID"
         value = var.project_id
+      }
+      
+      env {
+        name  = "FIRESTORE_DATABASE_NAME"
+        value = var.firestore_database_name
       }
 
       ports {

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -1,7 +1,7 @@
 # Firestore Database
 resource "google_firestore_database" "oauth_database" {
   project     = var.project_id
-  name        = "(default)"
+  name        = var.firestore_database_name
   location_id = var.region
   type        = "FIRESTORE_NATIVE"
   

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,6 +51,11 @@ variable "billing_service_name" {
   default     = "simple-billing"
 }
 
+variable "firestore_database_name" {
+  description = "Firestore database name"
+  type        = string
+}
+
 
 
 variable "official_base_url" {


### PR DESCRIPTION
## Summary
Complete staging environment setup with full isolation from production.

## Changes
- **Workflows**: New GitHub Actions for staging (`staging` branch) and production (`main` branch) deployments
- **Database isolation**: Production uses `production` database, staging uses `staging` database
- **Service isolation**: All services get `-staging` suffix in staging environment
- **Infrastructure**: Added Artifact Registry, removed implicit defaults

## Deployment
After merge:
1. Create GitHub environments (staging, production) in repository settings
2. Configure environment-specific secrets
3. Push to `staging` branch to deploy
