### PR TITLE
Implement API key service with LRU caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Build and Push Frontend Container
       working-directory: ./apps/frontend
       run: |-
-        docker build -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-frontend:${{ github.sha }}" .
+        docker build --build-arg VITE_BACKEND_URL="${{ env.TF_VAR_backend_url }}" -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-frontend:${{ github.sha }}" .
         docker push "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-frontend:${{ github.sha }}"
 
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
       group: deploy-${{ inputs.deploy_environment }}
       cancel-in-progress: false
     env:
-      TF_VAR_backend_url: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
+      BACKEND_URL: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
     
     steps:
     - name: Checkout
@@ -118,7 +118,7 @@ jobs:
     - name: Build and Push Frontend Container
       working-directory: ./apps/frontend
       run: |-
-        docker build --build-arg VITE_BACKEND_URL="${{ env.TF_VAR_backend_url }}" -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-frontend:${{ github.sha }}" .
+        docker build --build-arg VITE_BACKEND_URL="${{ env.BACKEND_URL }}" -t "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-frontend:${{ github.sha }}" .
         docker push "${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/simple-relay/simple-frontend:${{ github.sha }}"
 
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
         TF_VAR_resend_api_key: ${{ inputs.deploy_environment == 'production' && secrets.RESEND_API_KEY_PRODUCTION || secrets.RESEND_API_KEY_STAGING }}
         TF_VAR_resend_from_email: ${{ secrets.RESEND_FROM_EMAIL }}
         TF_VAR_cookie_secret: ${{ inputs.deploy_environment == 'production' && secrets.COOKIE_SECRET_PRODUCTION || secrets.COOKIE_SECRET_STAGING }}
+        TF_VAR_backend_url: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
       run: terraform plan -input=false -no-color
 
   terraform-deploy:
@@ -142,4 +143,5 @@ jobs:
         TF_VAR_resend_api_key: ${{ inputs.deploy_environment == 'production' && secrets.RESEND_API_KEY_PRODUCTION || secrets.RESEND_API_KEY_STAGING }}
         TF_VAR_resend_from_email: ${{ secrets.RESEND_FROM_EMAIL }}
         TF_VAR_cookie_secret: ${{ inputs.deploy_environment == 'production' && secrets.COOKIE_SECRET_PRODUCTION || secrets.COOKIE_SECRET_STAGING }}
+        TF_VAR_backend_url: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
       run: terraform apply -input=false -auto-approve -no-color

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,6 @@ jobs:
         TF_VAR_resend_api_key: ${{ inputs.deploy_environment == 'production' && secrets.RESEND_API_KEY_PRODUCTION || secrets.RESEND_API_KEY_STAGING }}
         TF_VAR_resend_from_email: ${{ secrets.RESEND_FROM_EMAIL }}
         TF_VAR_cookie_secret: ${{ inputs.deploy_environment == 'production' && secrets.COOKIE_SECRET_PRODUCTION || secrets.COOKIE_SECRET_STAGING }}
-        TF_VAR_backend_url: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
       run: terraform plan -input=false -no-color
 
   terraform-deploy:
@@ -145,5 +144,4 @@ jobs:
         TF_VAR_resend_api_key: ${{ inputs.deploy_environment == 'production' && secrets.RESEND_API_KEY_PRODUCTION || secrets.RESEND_API_KEY_STAGING }}
         TF_VAR_resend_from_email: ${{ secrets.RESEND_FROM_EMAIL }}
         TF_VAR_cookie_secret: ${{ inputs.deploy_environment == 'production' && secrets.COOKIE_SECRET_PRODUCTION || secrets.COOKIE_SECRET_STAGING }}
-        TF_VAR_backend_url: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
       run: terraform apply -input=false -auto-approve -no-color

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,6 @@ jobs:
         TF_VAR_firestore_database_name: simple-relay-db
         TF_VAR_deploy_environment: ${{ inputs.deploy_environment }}
         TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
-        TF_VAR_client_secret_key: ${{ secrets.ALLOWED_CLIENT_SECRET_KEY }}
         TF_VAR_resend_api_key: ${{ inputs.deploy_environment == 'production' && secrets.RESEND_API_KEY_PRODUCTION || secrets.RESEND_API_KEY_STAGING }}
         TF_VAR_resend_from_email: ${{ secrets.RESEND_FROM_EMAIL }}
         TF_VAR_cookie_secret: ${{ inputs.deploy_environment == 'production' && secrets.COOKIE_SECRET_PRODUCTION || secrets.COOKIE_SECRET_STAGING }}
@@ -140,7 +139,6 @@ jobs:
         TF_VAR_firestore_database_name: simple-relay-db
         TF_VAR_deploy_environment: ${{ inputs.deploy_environment }}
         TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
-        TF_VAR_client_secret_key: ${{ secrets.ALLOWED_CLIENT_SECRET_KEY }}
         TF_VAR_resend_api_key: ${{ inputs.deploy_environment == 'production' && secrets.RESEND_API_KEY_PRODUCTION || secrets.RESEND_API_KEY_STAGING }}
         TF_VAR_resend_from_email: ${{ secrets.RESEND_FROM_EMAIL }}
         TF_VAR_cookie_secret: ${{ inputs.deploy_environment == 'production' && secrets.COOKIE_SECRET_PRODUCTION || secrets.COOKIE_SECRET_STAGING }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,8 @@ jobs:
     concurrency: 
       group: deploy-${{ inputs.deploy_environment }}
       cancel-in-progress: false
+    env:
+      TF_VAR_backend_url: ${{ inputs.deploy_environment == 'production' && vars.BACKEND_PRODUCTION_URL || vars.BACKEND_STAGING_URL }}
     
     steps:
     - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,13 @@ simple-relay-468808
 # Manage app configuration
 ./scripts/config-manager.sh -p simple-relay-468808 -d DATABASE_NAME -c get -k CONFIG_KEY
 ./scripts/config-manager.sh -p simple-relay-468808 -d DATABASE_NAME -c set -k CONFIG_KEY -v VALUE
+
+# Grant API access to users
+./scripts/grant-api-access.sh -e USER_EMAIL -p simple-relay-468808 -d simple-relay-db-staging
+./scripts/grant-api-access.sh -e USER_EMAIL -p simple-relay-468808 -d simple-relay-db-production
+
+# Revoke API access from users
+./scripts/grant-api-access.sh -e USER_EMAIL -p simple-relay-468808 -d DATABASE_NAME -r
 ```
 
 ## Development Server Rules

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -214,7 +214,7 @@ func main() {
 	
 	
 	// Proxy all requests with API key validation
-	r.PathPrefix("/").HandlerFunc(clientApiKeyValidationMiddleware(config.AllowedClientSecretKey, proxyHandler))
+	r.PathPrefix("/").HandlerFunc(proxyHandler)
 	
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -336,24 +336,6 @@ func addOAuthBetaHeader(req *http.Request) {
 	}
 }
 
-func clientApiKeyValidationMiddleware(allowedClientSecretKey string, next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Get API secret key from Authorization header
-		var apiSecretKey string
-		authHeader := r.Header.Get("Authorization")
-		if strings.HasPrefix(authHeader, "Bearer ") {
-			apiSecretKey = strings.TrimPrefix(authHeader, "Bearer ")
-		}
-		
-		// Check if API secret key matches
-		if apiSecretKey != allowedClientSecretKey {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		
-		next(w, r)
-	}
-}
 
 // multiCloser closes multiple io.Closers
 type multiCloser []io.Closer

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -364,6 +364,3 @@ func extractUserIdFromAPIKey(req *http.Request, apiKeyService *services.ApiKeySe
 	
 	return userId
 }
-
-
-

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -120,21 +120,14 @@ func main() {
 	
 	// Create a custom handler that checks authentication before proxying
 	proxyHandler := func(w http.ResponseWriter, req *http.Request) {
-		log.Printf("[DEBUG] Processing request: %s %s", req.Method, req.URL.Path)
-		log.Printf("[DEBUG] Authorization header: %s", req.Header.Get("Authorization"))
-		
 		// Extract user ID from API key
 		userId := extractUserIdFromAPIKey(req, apiKeyService)
-		log.Printf("[DEBUG] Extracted userId: %s", userId)
 		
 		// Reject request if no valid API key provided
 		if userId == "" {
-			log.Printf("[DEBUG] No valid userId found, returning 401")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
-		
-		log.Printf("[DEBUG] Authentication successful for userId: %s", userId)
 		
 		// Store user ID in request context for proxy director
 		ctx := context.WithValue(req.Context(), "userId", userId)
@@ -351,31 +344,24 @@ func (mc multiCloser) Close() error {
 // extractUserIdFromAPIKey extracts user ID from API key in Authorization header
 func extractUserIdFromAPIKey(req *http.Request, apiKeyService *services.ApiKeyService) string {
 	authHeader := req.Header.Get("Authorization")
-	log.Printf("[DEBUG] Auth header: %s", authHeader)
 	
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		log.Printf("[DEBUG] Auth header doesn't start with 'Bearer '")
 		return ""
 	}
 	
 	apiKey := strings.TrimPrefix(authHeader, "Bearer ")
-	log.Printf("[DEBUG] Extracted API key: %s", apiKey)
 	
 	// Look up user ID by API key with caching
 	// Note: For convenience, we use email address as userId in our system
 	userId, err := apiKeyService.FindUserEmailByApiKey(req.Context(), apiKey)
-	log.Printf("[DEBUG] FindUserEmailByApiKey result - userId: %s, err: %v", userId, err)
 	
 	if err != nil {
-		log.Printf("[DEBUG] Error from FindUserEmailByApiKey: %v", err)
 		return ""
 	}
 	if userId == "" {
-		log.Printf("[DEBUG] Empty userId returned from FindUserEmailByApiKey")
 		return ""
 	}
 	
-	log.Printf("[DEBUG] Successfully resolved userId: %s", userId)
 	return userId
 }
 

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -139,9 +139,7 @@ func main() {
 	proxy.Director = func(req *http.Request) {
 		userId := req.Context().Value("userId").(string)
 		
-		userID := userId
-		
-		tokenBinding, err := oauthStore.GetValidTokenForUser(userID)
+		tokenBinding, err := oauthStore.GetValidTokenForUser(userId)
 		if err != nil {
 			// Fail the request if no valid OAuth token
 			return

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -38,7 +38,6 @@ func getIdentityToken(audience string) (string, error) {
 
 type Config struct {
 	APIKey                   string
-	AllowedClientSecretKey   string
 	OfficialTarget           *url.URL
 	BillingServiceURL        string
 	ProjectID                string
@@ -57,11 +56,6 @@ func loadConfig() *Config {
 		log.Fatal("API_SECRET_KEY environment variable is required")
 	}
 	
-	// Get allowed client secret key from environment variable
-	allowedClientSecretKey := os.Getenv("ALLOWED_CLIENT_SECRET_KEY")
-	if allowedClientSecretKey == "" {
-		log.Fatal("ALLOWED_CLIENT_SECRET_KEY environment variable is required")
-	}
 
 	// Get official base URL from environment variable
 	var officialTarget *url.URL
@@ -97,7 +91,6 @@ func loadConfig() *Config {
 
 	return &Config{
 		APIKey:                   apiKey,
-		AllowedClientSecretKey:   allowedClientSecretKey,
 		OfficialTarget:           officialTarget,
 		BillingServiceURL:        billingServiceURL,
 		ProjectID:                projectID,

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -120,14 +120,19 @@ func main() {
 	
 	// Create a custom handler that checks authentication before proxying
 	proxyHandler := func(w http.ResponseWriter, req *http.Request) {
+		log.Printf("DEBUG: Processing request to %s", req.URL.Path)
+		
 		// Extract user ID from API key
 		userId := extractUserIdFromAPIKey(req, apiKeyService)
 		
 		// Reject request if no valid API key provided
 		if userId == "" {
+			log.Printf("DEBUG: Rejecting request - no valid user ID found")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+		
+		log.Printf("DEBUG: Request authorized for user: %s", userId)
 		
 		// Store user ID in request context for proxy director
 		ctx := context.WithValue(req.Context(), "userId", userId)
@@ -344,23 +349,37 @@ func (mc multiCloser) Close() error {
 // extractUserIdFromAPIKey extracts user ID from API key in Authorization header
 func extractUserIdFromAPIKey(req *http.Request, apiKeyService *services.ApiKeyService) string {
 	authHeader := req.Header.Get("Authorization")
+	log.Printf("DEBUG: Authorization header present: %t", authHeader != "")
 	if !strings.HasPrefix(authHeader, "Bearer ") {
+		log.Printf("DEBUG: No Bearer token found in auth header")
 		return ""
 	}
 	
 	apiKey := strings.TrimPrefix(authHeader, "Bearer ")
+	log.Printf("DEBUG: Extracted API key: %s", maskApiKey(apiKey))
 	
 	// Look up user ID by API key with caching
 	// Note: For convenience, we use email address as userId in our system
 	userId, err := apiKeyService.FindUserEmailByApiKey(req.Context(), apiKey)
 	if err != nil {
+		log.Printf("DEBUG: Error looking up API key: %v", err)
 		return ""
 	}
 	if userId == "" {
+		log.Printf("DEBUG: No user found for API key")
 		return ""
 	}
 	
+	log.Printf("DEBUG: Found user: %s", userId)
 	return userId
+}
+
+// maskApiKey masks an API key for logging (shows first 8 and last 4 chars)
+func maskApiKey(apiKey string) string {
+	if len(apiKey) <= 12 {
+		return apiKey
+	}
+	return apiKey[:8] + "..." + apiKey[len(apiKey)-4:]
 }
 
 

--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -120,14 +120,21 @@ func main() {
 	
 	// Create a custom handler that checks authentication before proxying
 	proxyHandler := func(w http.ResponseWriter, req *http.Request) {
+		log.Printf("[DEBUG] Processing request: %s %s", req.Method, req.URL.Path)
+		log.Printf("[DEBUG] Authorization header: %s", req.Header.Get("Authorization"))
+		
 		// Extract user ID from API key
 		userId := extractUserIdFromAPIKey(req, apiKeyService)
+		log.Printf("[DEBUG] Extracted userId: %s", userId)
 		
 		// Reject request if no valid API key provided
 		if userId == "" {
+			log.Printf("[DEBUG] No valid userId found, returning 401")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+		
+		log.Printf("[DEBUG] Authentication successful for userId: %s", userId)
 		
 		// Store user ID in request context for proxy director
 		ctx := context.WithValue(req.Context(), "userId", userId)
@@ -344,22 +351,31 @@ func (mc multiCloser) Close() error {
 // extractUserIdFromAPIKey extracts user ID from API key in Authorization header
 func extractUserIdFromAPIKey(req *http.Request, apiKeyService *services.ApiKeyService) string {
 	authHeader := req.Header.Get("Authorization")
+	log.Printf("[DEBUG] Auth header: %s", authHeader)
+	
 	if !strings.HasPrefix(authHeader, "Bearer ") {
+		log.Printf("[DEBUG] Auth header doesn't start with 'Bearer '")
 		return ""
 	}
 	
 	apiKey := strings.TrimPrefix(authHeader, "Bearer ")
+	log.Printf("[DEBUG] Extracted API key: %s", apiKey)
 	
 	// Look up user ID by API key with caching
 	// Note: For convenience, we use email address as userId in our system
 	userId, err := apiKeyService.FindUserEmailByApiKey(req.Context(), apiKey)
+	log.Printf("[DEBUG] FindUserEmailByApiKey result - userId: %s, err: %v", userId, err)
+	
 	if err != nil {
+		log.Printf("[DEBUG] Error from FindUserEmailByApiKey: %v", err)
 		return ""
 	}
 	if userId == "" {
+		log.Printf("[DEBUG] Empty userId returned from FindUserEmailByApiKey")
 		return ""
 	}
 	
+	log.Printf("[DEBUG] Successfully resolved userId: %s", userId)
 	return userId
 }
 

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -49,25 +50,36 @@ func (s *ApiKeyService) FindUserEmailByApiKey(ctx context.Context, apiKey string
 	// Check cache first
 	if entry, exists := s.cache.Get(apiKey); exists {
 		if time.Since(entry.Timestamp) < s.cacheDuration {
+			log.Printf("DEBUG: Cache hit for API key, user: %s", entry.UserEmail)
 			return entry.UserEmail, nil
 		}
 		// Remove expired entry
 		s.cache.Remove(apiKey)
+		log.Printf("DEBUG: Cache entry expired, removed from cache")
 	}
+
+	log.Printf("DEBUG: Querying Firestore for API key in collection: %s", s.collection)
 
 	// Fetch from Firestore
 	doc, err := s.client.Collection(s.collection).Doc(apiKey).Get(ctx)
 	if err != nil {
+		log.Printf("DEBUG: Firestore query error: %v", err)
 		if doc != nil && !doc.Exists() {
+			log.Printf("DEBUG: API key document does not exist")
 			return "", nil
 		}
 		return "", fmt.Errorf("error fetching API key: %w", err)
 	}
 
+	log.Printf("DEBUG: Document exists: %t", doc.Exists())
+
 	var binding ApiKeyBinding
 	if err := doc.DataTo(&binding); err != nil {
+		log.Printf("DEBUG: Error parsing document data: %v", err)
 		return "", fmt.Errorf("error parsing API key binding: %w", err)
 	}
+
+	log.Printf("DEBUG: Found user email in database: %s", binding.UserEmail)
 
 	// Cache the result
 	s.cache.Add(apiKey, &CacheEntry{

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -1,0 +1,81 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// ApiKeyBinding represents an API key binding document
+type ApiKeyBinding struct {
+	ApiKey    string    `firestore:"api_key" json:"api_key"`
+	UserEmail string    `firestore:"user_email" json:"user_email"`
+	CreatedAt time.Time `firestore:"created_at" json:"created_at"`
+}
+
+// CacheEntry represents a cached API key lookup result
+type CacheEntry struct {
+	UserEmail string
+	Timestamp time.Time
+}
+
+// ApiKeyService handles API key operations with caching
+type ApiKeyService struct {
+	client        *firestore.Client
+	collection    string
+	cache         *lru.Cache[string, *CacheEntry]
+	cacheDuration time.Duration
+}
+
+// NewApiKeyService creates a new API key service with caching
+func NewApiKeyService(client *firestore.Client) *ApiKeyService {
+	// Create LRU cache with capacity of 1000 entries
+	cache, _ := lru.New[string, *CacheEntry](1000)
+	
+	return &ApiKeyService{
+		client:        client,
+		collection:    "api_key_bindings",
+		cache:         cache,
+		cacheDuration: time.Minute, // 1 minute cache
+	}
+}
+
+// FindUserEmailByApiKey looks up the user email associated with an API key
+// Returns the user email or empty string if not found
+func (s *ApiKeyService) FindUserEmailByApiKey(ctx context.Context, apiKey string) (string, error) {
+	// Check cache first
+	if entry, exists := s.cache.Get(apiKey); exists {
+		if time.Since(entry.Timestamp) < s.cacheDuration {
+			return entry.UserEmail, nil
+		}
+		// Remove expired entry
+		s.cache.Remove(apiKey)
+	}
+
+	// Fetch from Firestore
+	doc, err := s.client.Collection(s.collection).Doc(apiKey).Get(ctx)
+	if err != nil {
+		if doc != nil && !doc.Exists() {
+			return "", nil
+		}
+		return "", fmt.Errorf("error fetching API key: %w", err)
+	}
+
+	var binding ApiKeyBinding
+	if err := doc.DataTo(&binding); err != nil {
+		return "", fmt.Errorf("error parsing API key binding: %w", err)
+	}
+
+	// Cache the result
+	s.cache.Add(apiKey, &CacheEntry{
+		UserEmail: binding.UserEmail,
+		Timestamp: time.Now(),
+	})
+	
+	return binding.UserEmail, nil
+}
+
+

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -38,7 +38,7 @@ func NewApiKeyService(client *firestore.Client) *ApiKeyService {
 		client:        client,
 		collection:    "api_key_bindings",
 		cache:         cache,
-		cacheDuration: time.Minute, // 1 minute cache
+		cacheDuration: 5 * time.Minute, // 5 minute cache
 	}
 }
 

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -65,53 +65,68 @@ func (s *ApiKeyService) FindUserEmailByApiKey(ctx context.Context, apiKey string
 		fmt.Printf("[DEBUG-APIKEY] Cache expired for API key: %s\n", apiKey)
 	}
 
-	// Query for users that have this API key in their api_keys array
-	query := s.client.Collection(s.collection).Where("api_keys", "array-contains", map[string]interface{}{
-		"api_key": apiKey,
-	})
+	// Since array-contains doesn't work with partial map matching,
+	// we need to iterate through all users to find the one with this API key
+	fmt.Printf("[DEBUG-APIKEY] Iterating through all users to find API key: %s\n", apiKey)
+	
+	iter := s.client.Collection(s.collection).Documents(ctx)
+	defer iter.Stop()
 
-	fmt.Printf("[DEBUG-APIKEY] Executing Firestore query for API key: %s\n", apiKey)
-	docs, err := query.Documents(ctx).GetAll()
-	if err != nil {
-		fmt.Printf("[DEBUG-APIKEY] Query error for API key %s: %v\n", apiKey, err)
-		return "", fmt.Errorf("error querying users: %w", err)
+	var foundUser *User
+	for {
+		doc, err := iter.Next()
+		if err != nil {
+			if err.Error() == "iterator done" {
+				break
+			}
+			fmt.Printf("[DEBUG-APIKEY] Iterator error for API key %s: %v\n", apiKey, err)
+			return "", fmt.Errorf("error iterating users: %w", err)
+		}
+
+		var user User
+		if err := doc.DataTo(&user); err != nil {
+			fmt.Printf("[DEBUG-APIKEY] Error parsing user document %s: %v\n", doc.Ref.ID, err)
+			continue // Skip this document if we can't parse it
+		}
+
+		fmt.Printf("[DEBUG-APIKEY] Checking user %s with %d API keys\n", user.email, len(user.api_keys))
+
+		// Check if this user has the API key
+		for _, key := range user.api_keys {
+			fmt.Printf("[DEBUG-APIKEY] Comparing API key: %s vs %s\n", key.api_key, apiKey)
+			if key.api_key == apiKey {
+				fmt.Printf("[DEBUG-APIKEY] Found matching API key for user: %s\n", user.email)
+				foundUser = &user
+				break
+			}
+		}
+		
+		if foundUser != nil {
+			break
+		}
 	}
 
-	fmt.Printf("[DEBUG-APIKEY] Query returned %d documents for API key: %s\n", len(docs), apiKey)
-
-	// Should only be one user with this API key
-	if len(docs) == 0 {
+	if foundUser == nil {
 		fmt.Printf("[DEBUG-APIKEY] No user found for API key: %s\n", apiKey)
 		return "", nil // API key not found
 	}
 
-	if len(docs) > 1 {
-		fmt.Printf("[DEBUG-APIKEY] Multiple users found for API key: %s\n", apiKey)
-		return "", fmt.Errorf("data integrity error: API key %s found in multiple users", apiKey)
-	}
-
-	var user User
-	if err := docs[0].DataTo(&user); err != nil {
-		fmt.Printf("[DEBUG-APIKEY] Error parsing user data for API key %s: %v\n", apiKey, err)
-		return "", fmt.Errorf("error parsing user data: %w", err)
-	}
-
-	fmt.Printf("[DEBUG-APIKEY] Found user: email=%s, api_enabled=%t for API key: %s\n", user.email, user.api_enabled, apiKey)
+	fmt.Printf("[DEBUG-APIKEY] Found user: email=%s, api_enabled=%t for API key: %s\n", foundUser.email, foundUser.api_enabled, apiKey)
 
 	// Check if API is enabled for this user
-	if !user.api_enabled {
-		fmt.Printf("[DEBUG-APIKEY] API access disabled for user: %s\n", user.email)
+	if !foundUser.api_enabled {
+		fmt.Printf("[DEBUG-APIKEY] API access disabled for user: %s\n", foundUser.email)
 		return "", nil // API access disabled
 	}
 
 	// Cache the result
 	s.cache.Add(apiKey, &CacheEntry{
-		UserEmail: user.email,
+		UserEmail: foundUser.email,
 		Timestamp: time.Now(),
 	})
 
-	fmt.Printf("[DEBUG-APIKEY] Successfully authenticated user: %s for API key: %s\n", user.email, apiKey)
-	return user.email, nil
+	fmt.Printf("[DEBUG-APIKEY] Successfully authenticated user: %s for API key: %s\n", foundUser.email, apiKey)
+	return foundUser.email, nil
 }
 
 

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -9,17 +9,10 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-// ApiKey represents an API key within a user document
-type ApiKey struct {
+// ApiKeyBinding represents an API key binding document
+type ApiKeyBinding struct {
 	api_key    string
-	created_at string
-}
-
-// User represents a user document with API keys
-type User struct {
-	email       string
-	api_keys    []ApiKey
-	api_enabled bool
+	user_email string
 }
 
 // CacheEntry represents a cached API key lookup result
@@ -43,7 +36,7 @@ func NewApiKeyService(client *firestore.Client) *ApiKeyService {
 	
 	return &ApiKeyService{
 		client:        client,
-		collection:    "users",
+		collection:    "api_key_bindings",
 		cache:         cache,
 		cacheDuration: time.Minute, // 1 minute cache
 	}
@@ -65,68 +58,34 @@ func (s *ApiKeyService) FindUserEmailByApiKey(ctx context.Context, apiKey string
 		fmt.Printf("[DEBUG-APIKEY] Cache expired for API key: %s\n", apiKey)
 	}
 
-	// Since array-contains doesn't work with partial map matching,
-	// we need to iterate through all users to find the one with this API key
-	fmt.Printf("[DEBUG-APIKEY] Iterating through all users to find API key: %s\n", apiKey)
-	
-	iter := s.client.Collection(s.collection).Documents(ctx)
-	defer iter.Stop()
-
-	var foundUser *User
-	for {
-		doc, err := iter.Next()
-		if err != nil {
-			if err.Error() == "iterator done" {
-				break
-			}
-			fmt.Printf("[DEBUG-APIKEY] Iterator error for API key %s: %v\n", apiKey, err)
-			return "", fmt.Errorf("error iterating users: %w", err)
+	// Direct lookup using API key as document ID
+	fmt.Printf("[DEBUG-APIKEY] Looking up document with ID: %s\n", apiKey)
+	doc, err := s.client.Collection(s.collection).Doc(apiKey).Get(ctx)
+	if err != nil {
+		if doc != nil && !doc.Exists() {
+			fmt.Printf("[DEBUG-APIKEY] API key document not found: %s\n", apiKey)
+			return "", nil // API key not found
 		}
-
-		var user User
-		if err := doc.DataTo(&user); err != nil {
-			fmt.Printf("[DEBUG-APIKEY] Error parsing user document %s: %v\n", doc.Ref.ID, err)
-			continue // Skip this document if we can't parse it
-		}
-
-		fmt.Printf("[DEBUG-APIKEY] Checking user %s with %d API keys\n", user.email, len(user.api_keys))
-
-		// Check if this user has the API key
-		for _, key := range user.api_keys {
-			fmt.Printf("[DEBUG-APIKEY] Comparing API key: %s vs %s\n", key.api_key, apiKey)
-			if key.api_key == apiKey {
-				fmt.Printf("[DEBUG-APIKEY] Found matching API key for user: %s\n", user.email)
-				foundUser = &user
-				break
-			}
-		}
-		
-		if foundUser != nil {
-			break
-		}
+		fmt.Printf("[DEBUG-APIKEY] Error fetching API key document: %v\n", err)
+		return "", fmt.Errorf("error fetching API key: %w", err)
 	}
 
-	if foundUser == nil {
-		fmt.Printf("[DEBUG-APIKEY] No user found for API key: %s\n", apiKey)
-		return "", nil // API key not found
+	var binding ApiKeyBinding
+	if err := doc.DataTo(&binding); err != nil {
+		fmt.Printf("[DEBUG-APIKEY] Error parsing API key binding: %v\n", err)
+		return "", fmt.Errorf("error parsing API key binding: %w", err)
 	}
 
-	fmt.Printf("[DEBUG-APIKEY] Found user: email=%s, api_enabled=%t for API key: %s\n", foundUser.email, foundUser.api_enabled, apiKey)
-
-	// Check if API is enabled for this user
-	if !foundUser.api_enabled {
-		fmt.Printf("[DEBUG-APIKEY] API access disabled for user: %s\n", foundUser.email)
-		return "", nil // API access disabled
-	}
+	fmt.Printf("[DEBUG-APIKEY] Found API key binding - user_email: %s\n", binding.user_email)
 
 	// Cache the result
 	s.cache.Add(apiKey, &CacheEntry{
-		UserEmail: foundUser.email,
+		UserEmail: binding.user_email,
 		Timestamp: time.Now(),
 	})
 
-	fmt.Printf("[DEBUG-APIKEY] Successfully authenticated user: %s for API key: %s\n", foundUser.email, apiKey)
-	return foundUser.email, nil
+	fmt.Printf("[DEBUG-APIKEY] Successfully authenticated user: %s for API key: %s\n", binding.user_email, apiKey)
+	return binding.user_email, nil
 }
 
 

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -11,8 +11,8 @@ import (
 
 // ApiKeyBinding represents an API key binding document
 type ApiKeyBinding struct {
-	api_key    string
-	user_email string
+	ApiKey    string `firestore:"api_key" json:"api_key"`
+	UserEmail string `firestore:"user_email" json:"user_email"`
 }
 
 // CacheEntry represents a cached API key lookup result
@@ -76,16 +76,16 @@ func (s *ApiKeyService) FindUserEmailByApiKey(ctx context.Context, apiKey string
 		return "", fmt.Errorf("error parsing API key binding: %w", err)
 	}
 
-	fmt.Printf("[DEBUG-APIKEY] Found API key binding - user_email: %s\n", binding.user_email)
+	fmt.Printf("[DEBUG-APIKEY] Found API key binding - user_email: %s\n", binding.UserEmail)
 
 	// Cache the result
 	s.cache.Add(apiKey, &CacheEntry{
-		UserEmail: binding.user_email,
+		UserEmail: binding.UserEmail,
 		Timestamp: time.Now(),
 	})
 
-	fmt.Printf("[DEBUG-APIKEY] Successfully authenticated user: %s for API key: %s\n", binding.user_email, apiKey)
-	return binding.user_email, nil
+	fmt.Printf("[DEBUG-APIKEY] Successfully authenticated user: %s for API key: %s\n", binding.UserEmail, apiKey)
+	return binding.UserEmail, nil
 }
 
 

--- a/apps/backend/internal/services/apikey.go
+++ b/apps/backend/internal/services/apikey.go
@@ -12,9 +12,8 @@ import (
 
 // ApiKeyBinding represents an API key binding document
 type ApiKeyBinding struct {
-	ApiKey    string    `firestore:"api_key" json:"api_key"`
-	UserEmail string    `firestore:"user_email" json:"user_email"`
-	CreatedAt time.Time `firestore:"created_at" json:"created_at"`
+	ApiKey    string `firestore:"api_key" json:"api_key"`
+	UserEmail string `firestore:"user_email" json:"user_email"`
 }
 
 // CacheEntry represents a cached API key lookup result

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -10,6 +10,10 @@ RUN npm install
 # Copy source code
 COPY . .
 
+# Accept backend URL as build argument for Vite
+ARG VITE_BACKEND_URL
+ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
+
 # Build the application
 RUN npm run build
 

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -278,15 +278,7 @@ app.get('*', async (req: Request, res: Response) => {
   try {
     const htmlPath = path.join(process.cwd(), 'dist/index.html');
     const html = readFileSync(htmlPath, 'utf8');
-    
-    // Inject backend URL into the HTML
-    const backendUrl = process.env.BACKEND_URL || 'https://simple-relay-staging-573916960175.us-central1.run.app';
-    const injectedHtml = html.replace(
-      '<head>',
-      `<head><script>window.__BACKEND_URL__ = "${backendUrl}";</script>`
-    );
-    
-    res.send(injectedHtml);
+    res.send(html);
   } catch (error) {
     console.error('Error serving HTML:', error);
     res.status(500).send('Server error');

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -234,8 +234,8 @@ app.post('/api/api-keys', requireAuth, async (req, res) => {
     }
     
     // Generate API key on server
-    const apiKey = 'ak-' + Array.from(crypto.getRandomValues(new Uint8Array(24)))
-      .map(b => b.toString(16).padStart(2, '0'))
+    const apiKey = 'ak-' + Array.from(crypto.getRandomValues(new Uint8Array(16)))
+      .map(b => b.toString(36))
       .join('');
     
     const newBinding = await ApiKeyDatabase.create({

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -211,7 +211,10 @@ app.get('/api/api-keys', requireAuth, async (req, res) => {
       created_at: key.created_at.toISOString(),
     }));
     
-    res.json(apiKeys);
+    res.json({
+      api_keys: apiKeys,
+      api_enabled: user.api_enabled
+    });
   } catch (error) {
     console.error('Error fetching API keys:', error);
     res.status(500).json({ error: 'Failed to fetch API keys' });

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -255,7 +255,16 @@ app.delete('/api/api-keys/:key', requireAuth, async (req, res) => {
 app.get('*', async (req: Request, res: Response) => {
   try {
     const htmlPath = path.join(process.cwd(), 'dist/index.html');
-    res.sendFile(htmlPath);
+    const html = readFileSync(htmlPath, 'utf8');
+    
+    // Inject backend URL into the HTML
+    const backendUrl = process.env.BACKEND_URL || 'https://simple-relay-staging-573916960175.us-central1.run.app';
+    const injectedHtml = html.replace(
+      '<head>',
+      `<head><script>window.__BACKEND_URL__ = "${backendUrl}";</script>`
+    );
+    
+    res.send(injectedHtml);
   } catch (error) {
     console.error('Error serving HTML:', error);
     res.status(500).send('Server error');

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -10,6 +10,7 @@ import validator from 'validator';
 import { sendVerificationEmail } from '../services/email.js';
 import { UserDatabase } from '../services/user-database.js';
 import { ConfigService } from '../services/config.js';
+import { ApiKeyDatabase } from '../services/api-key-database.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -199,17 +200,15 @@ app.post('/api/logout', (req, res) => {
 app.get('/api/api-keys', requireAuth, async (req, res) => {
   try {
     const email = (req as any).userEmail;
+    
+    // Get user to check api_enabled status
     const user = await UserDatabase.findByEmail(email);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
     
-    // Transform user's api_keys to match the expected format
-    const apiKeys = user.api_keys.map(key => ({
-      api_key: key.api_key,
-      user_email: user.email,
-      created_at: key.created_at.toISOString(),
-    }));
+    // Get API keys from separate collection
+    const apiKeys = await ApiKeyDatabase.findByUserEmail(email);
     
     res.json({
       api_keys: apiKeys,
@@ -225,23 +224,27 @@ app.post('/api/api-keys', requireAuth, async (req, res) => {
   try {
     const email = (req as any).userEmail;
     
+    // Check if API is enabled for this user
+    const user = await UserDatabase.findByEmail(email);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    
+    if (!user.api_enabled) {
+      return res.status(403).json({ error: 'API access is not enabled for this user' });
+    }
+    
     // Generate API key on server
     const apiKey = 'ak-' + Array.from(crypto.getRandomValues(new Uint8Array(24)))
       .map(b => b.toString(16).padStart(2, '0'))
       .join('');
     
-    const updatedUser = await UserDatabase.addApiKey(email, apiKey);
-    if (!updatedUser) {
-      return res.status(404).json({ error: 'User not found' });
-    }
-    
-    // Return the new API key in the expected format
-    const newApiKey = updatedUser.api_keys.find(key => key.api_key === apiKey);
-    res.json({
+    const newBinding = await ApiKeyDatabase.create({
       api_key: apiKey,
       user_email: email,
-      created_at: newApiKey?.created_at.toISOString(),
     });
+    
+    res.json(newBinding);
   } catch (error) {
     console.error('Error creating API key:', error);
     if (error instanceof Error && error.message.includes('maximum of 3 API keys')) {
@@ -257,17 +260,12 @@ app.delete('/api/api-keys/:key', requireAuth, async (req, res) => {
     const apiKey = req.params.key;
     
     // Verify the API key belongs to the user
-    const user = await UserDatabase.findByEmail(email);
-    if (!user) {
-      return res.status(404).json({ error: 'User not found' });
-    }
-    
-    const hasApiKey = user.api_keys.some(key => key.api_key === apiKey);
-    if (!hasApiKey) {
+    const binding = await ApiKeyDatabase.findByApiKey(apiKey);
+    if (!binding || binding.user_email !== email) {
       return res.status(404).json({ error: 'API key not found' });
     }
     
-    await UserDatabase.removeApiKey(email, apiKey);
+    await ApiKeyDatabase.deleteApiKey(apiKey);
     res.json({ message: 'API key deleted successfully' });
   } catch (error) {
     console.error('Error deleting API key:', error);

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -4,7 +4,6 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { readFileSync } from 'fs';
 import rateLimit from 'express-rate-limit';
 import validator from 'validator';
 import { sendVerificationEmail } from '../services/email.js';
@@ -273,12 +272,10 @@ app.delete('/api/api-keys/:key', requireAuth, async (req, res) => {
   }
 });
 
-
-app.get('*', async (req: Request, res: Response) => {
+app.get('*', (req: Request, res: Response) => {
   try {
     const htmlPath = path.join(process.cwd(), 'dist/index.html');
-    const html = readFileSync(htmlPath, 'utf8');
-    res.send(html);
+    res.sendFile(htmlPath);
   } catch (error) {
     console.error('Error serving HTML:', error);
     res.status(500).send('Server error');

--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -233,8 +233,8 @@ app.post('/api/api-keys', requireAuth, async (req, res) => {
       return res.status(403).json({ error: 'API access is not enabled for this user' });
     }
     
-    // Generate API key on server
-    const apiKey = 'ak-' + Array.from(crypto.getRandomValues(new Uint8Array(16)))
+    // Generate API key on server (base36: 0-9, a-z)
+    const apiKey = 'ak-' + Array.from(crypto.getRandomValues(new Uint8Array(20)))
       .map(b => b.toString(36))
       .join('');
     

--- a/apps/frontend/services/user-database.ts
+++ b/apps/frontend/services/user-database.ts
@@ -182,7 +182,7 @@ class FirestoreUserDatabase {
               api_key: key.api_key,
               created_at: new Date(key.created_at),
             })),
-            enabled: userData.enabled !== undefined ? userData.enabled : true,
+            api_enabled: userData.api_enabled !== undefined ? userData.api_enabled : false,
           };
         }
       }

--- a/apps/frontend/services/user-database.ts
+++ b/apps/frontend/services/user-database.ts
@@ -1,11 +1,18 @@
 import { Firestore } from '@google-cloud/firestore';
 
+export interface ApiKey {
+  api_key: string;
+  created_at: Date;
+}
+
 export interface User {
   email: string;                    // Primary key
   created_at: Date;                 // Account creation timestamp
   last_login: Date | null;          // Last login timestamp
   verification_token: string | null; // Token for email verification
   verification_expires_at: Date | null; // Expiration time for verification token
+  api_keys: ApiKey[];               // Array of API keys for this user
+  api_enabled: boolean;             // Whether API access is enabled for this user
 }
 
 class FirestoreUserDatabase {
@@ -26,10 +33,12 @@ class FirestoreUserDatabase {
     });
   }
 
-  async create(user: Omit<User, 'created_at'>): Promise<User> {
+  async create(user: Omit<User, 'created_at' | 'api_keys' | 'api_enabled'>): Promise<User> {
     const newUser: User = {
       ...user,
       created_at: new Date(),
+      api_keys: [],
+      api_enabled: false,
     };
     
     const docRef = this.db.collection(this.collection).doc(user.email);
@@ -38,6 +47,11 @@ class FirestoreUserDatabase {
       created_at: newUser.created_at.toISOString(),
       last_login: newUser.last_login?.toISOString() || null,
       verification_expires_at: newUser.verification_expires_at?.toISOString() || null,
+      api_keys: newUser.api_keys.map(key => ({
+        api_key: key.api_key,
+        created_at: key.created_at.toISOString(),
+      })),
+      api_enabled: newUser.api_enabled,
     });
     
     return newUser;
@@ -58,6 +72,11 @@ class FirestoreUserDatabase {
       last_login: data.last_login ? new Date(data.last_login) : null,
       verification_token: data.verification_token || null,
       verification_expires_at: data.verification_expires_at ? new Date(data.verification_expires_at) : null,
+      api_keys: (data.api_keys || []).map((key: any) => ({
+        api_key: key.api_key,
+        created_at: new Date(key.created_at),
+      })),
+      api_enabled: data.api_enabled !== undefined ? data.api_enabled : false,
     };
   }
 
@@ -69,6 +88,13 @@ class FirestoreUserDatabase {
       last_login: updates.last_login?.toISOString() || null,
       verification_expires_at: updates.verification_expires_at?.toISOString() || null,
     };
+    
+    if (updates.api_keys) {
+      firestoreUpdates.api_keys = updates.api_keys.map(key => ({
+        api_key: key.api_key,
+        created_at: key.created_at.toISOString(),
+      }));
+    }
     
     await docRef.update(firestoreUpdates);
     return this.findByEmail(email);
@@ -102,6 +128,81 @@ class FirestoreUserDatabase {
       return false;
     }
     return user.verification_expires_at > new Date();
+  }
+
+  // API Key management methods
+  async addApiKey(email: string, apiKey: string): Promise<User | null> {
+    const user = await this.findByEmail(email);
+    if (!user) return null;
+    
+    // Check if user already has 3 API keys
+    if (user.api_keys.length >= 3) {
+      throw new Error('User already has maximum of 3 API keys');
+    }
+    
+    const newApiKey: ApiKey = {
+      api_key: apiKey,
+      created_at: new Date(),
+    };
+    
+    const updatedApiKeys = [...user.api_keys, newApiKey];
+    return this.updateUser(email, { api_keys: updatedApiKeys });
+  }
+
+  async removeApiKey(email: string, apiKey: string): Promise<User | null> {
+    const user = await this.findByEmail(email);
+    if (!user) return null;
+    
+    const updatedApiKeys = user.api_keys.filter(key => key.api_key !== apiKey);
+    return this.updateUser(email, { api_keys: updatedApiKeys });
+  }
+
+  async findUserByApiKey(apiKey: string): Promise<User | null> {
+    const query = this.db.collection(this.collection)
+      .where('api_keys', 'array-contains-any', [{ api_key: apiKey }]);
+    
+    const snapshot = await query.get();
+    
+    if (snapshot.empty) {
+      // Fallback: search through all users (less efficient but more reliable)
+      const allUsersSnapshot = await this.db.collection(this.collection).get();
+      
+      for (const doc of allUsersSnapshot.docs) {
+        const userData = doc.data();
+        const apiKeys = userData.api_keys || [];
+        
+        if (apiKeys.some((key: any) => key.api_key === apiKey)) {
+          return {
+            email: userData.email,
+            created_at: new Date(userData.created_at),
+            last_login: userData.last_login ? new Date(userData.last_login) : null,
+            verification_token: userData.verification_token || null,
+            verification_expires_at: userData.verification_expires_at ? new Date(userData.verification_expires_at) : null,
+            api_keys: apiKeys.map((key: any) => ({
+              api_key: key.api_key,
+              created_at: new Date(key.created_at),
+            })),
+            enabled: userData.enabled !== undefined ? userData.enabled : true,
+          };
+        }
+      }
+      return null;
+    }
+    
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    return {
+      email: data.email,
+      created_at: new Date(data.created_at),
+      last_login: data.last_login ? new Date(data.last_login) : null,
+      verification_token: data.verification_token || null,
+      verification_expires_at: data.verification_expires_at ? new Date(data.verification_expires_at) : null,
+      api_keys: (data.api_keys || []).map((key: any) => ({
+        api_key: key.api_key,
+        created_at: new Date(key.created_at),
+      })),
+      api_enabled: data.api_enabled !== undefined ? data.api_enabled : false,
+    };
   }
 
 }

--- a/apps/frontend/src/components/ApiKeyTable.scss
+++ b/apps/frontend/src/components/ApiKeyTable.scss
@@ -109,10 +109,10 @@
   background-color: #333;
   color: white;
   border: none;
-  padding: 6px 12px;
+  padding: 8px 16px;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 14px;
   transition: background-color 0.2s ease;
   
   &:hover:not(:disabled) {
@@ -129,10 +129,10 @@
   background-color: white;
   color: #333;
   border: 1px solid #ddd;
-  padding: 6px 12px;
+  padding: 8px 16px;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 14px;
   transition: all 0.2s ease;
   
   &:hover {

--- a/apps/frontend/src/components/ApiKeyTable.scss
+++ b/apps/frontend/src/components/ApiKeyTable.scss
@@ -68,6 +68,7 @@
   border-radius: 4px;
   background-color: white;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  gap: 20px;
 }
 
 .key-info {
@@ -101,6 +102,7 @@
 .key-actions {
   display: flex;
   gap: 12px;
+  align-items: center;
 }
 
 .copy-command-button {

--- a/apps/frontend/src/components/ApiKeyTable.scss
+++ b/apps/frontend/src/components/ApiKeyTable.scss
@@ -89,12 +89,28 @@
   color: #666;
 }
 
+.key-command {
+  margin-top: 8px;
+  padding: 8px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  
+  code {
+    font-family: 'Monaco', 'Menlo', monospace;
+    font-size: 11px;
+    color: #333;
+    word-break: break-all;
+    line-height: 1.4;
+  }
+}
+
 .key-actions {
   display: flex;
   gap: 12px;
 }
 
-.copy-button {
+.copy-button, .copy-command-button {
   background-color: #333;
   color: white;
   border: none;

--- a/apps/frontend/src/components/ApiKeyTable.scss
+++ b/apps/frontend/src/components/ApiKeyTable.scss
@@ -141,6 +141,17 @@
   }
 }
 
+.api-disabled-message {
+  background-color: #fff3cd;
+  color: #856404;
+  padding: 12px 16px;
+  border: 1px solid #ffeaa7;
+  border-radius: 4px;
+  margin: 16px 0;
+  font-size: 14px;
+  text-align: center;
+}
+
 // Modal styles
 .modal-overlay {
   position: fixed;

--- a/apps/frontend/src/components/ApiKeyTable.scss
+++ b/apps/frontend/src/components/ApiKeyTable.scss
@@ -76,13 +76,6 @@
   flex: 1;
 }
 
-.key-value {
-  font-family: 'Courier New', monospace;
-  font-size: 16px;
-  color: #333;
-  font-weight: normal;
-  margin-bottom: 8px;
-}
 
 .key-date {
   font-size: 14px;
@@ -110,7 +103,7 @@
   gap: 12px;
 }
 
-.copy-button, .copy-command-button {
+.copy-command-button {
   background-color: #333;
   color: white;
   border: none;
@@ -120,8 +113,13 @@
   font-size: 13px;
   transition: background-color 0.2s ease;
   
-  &:hover {
+  &:hover:not(:disabled) {
     background-color: #444;
+  }
+  
+  &:disabled {
+    background-color: #666;
+    cursor: default;
   }
 }
 

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -145,15 +145,9 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
         <span className="key-count">{apiKeys.length}/3 keys</span>
       </div>
 
-      {!apiEnabled && (
-        <div className="api-disabled-message">
-          API access is not enabled. Please contact us to enable access.
-        </div>
-      )}
-
       {apiKeys.length === 0 ? (
         <div className="no-keys">
-          Create your first key to get started.
+          {!apiEnabled ? 'API access is not enabled. Please contact us to enable access.' : 'Create your first key to get started.'}
         </div>
       ) : (
         <div className="key-list">

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -198,3 +198,8 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
     </div>
   );
 }
+
+function maskApiKey(apiKey: string): string {
+  if (apiKey.length <= 8) return apiKey;
+  return apiKey.substring(0, 6) + '...' + apiKey.substring(apiKey.length - 4);
+}

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -14,6 +14,7 @@ interface ApiKeyTableProps {
 
 export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
+  const [apiEnabled, setApiEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const [deleteModal, setDeleteModal] = useState<{ show: boolean; apiKey: string }>({ show: false, apiKey: '' });
@@ -30,8 +31,9 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
         credentials: 'include'
       });
       if (response.ok) {
-        const keys = await response.json();
-        setApiKeys(keys);
+        const data = await response.json();
+        setApiKeys(data.api_keys || data); // Handle both new and old response formats
+        setApiEnabled(data.api_enabled !== undefined ? data.api_enabled : true);
       } else {
         onMessage('Failed to load API keys');
       }
@@ -133,12 +135,18 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
         <button 
           className="create-key-button"
           onClick={createApiKey}
-          disabled={creating || apiKeys.length >= 3}
+          disabled={creating || apiKeys.length >= 3 || !apiEnabled}
         >
           {creating ? 'Creating...' : 'Create'}
         </button>
         <span className="key-count">{apiKeys.length}/3 keys</span>
       </div>
+
+      {!apiEnabled && (
+        <div className="api-disabled-message">
+          API access is not enabled. Please contact us to enable access.
+        </div>
+      )}
 
       {apiKeys.length === 0 ? (
         <div className="no-keys">
@@ -162,7 +170,7 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
                 <button 
                   className="copy-command-button"
                   onClick={() => copyCommand(key.api_key)}
-                  disabled={copiedCommand === key.api_key}
+                  disabled={copiedCommand === key.api_key || !apiEnabled}
                 >
                   {copiedCommand === key.api_key ? 'Copied' : 'Copy'}
                 </button>

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -118,10 +118,10 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
       setCopiedCommand(apiKey);
       onMessage('Command copied to clipboard');
       
-      // Reset after 2 seconds
+      // Reset after 1 second
       setTimeout(() => {
         setCopiedCommand(null);
-      }, 2000);
+      }, 1000);
     } catch (error) {
       onMessage('Failed to copy command');
     }
@@ -153,7 +153,7 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
 
       {apiKeys.length === 0 ? (
         <div className="no-keys">
-          No API keys yet. Create your first key to get started.
+          Create your first key to get started.
         </div>
       ) : (
         <div className="key-list">

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -164,7 +164,7 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
                   onClick={() => copyCommand(key.api_key)}
                   disabled={copiedCommand === key.api_key}
                 >
-                  {copiedCommand === key.api_key ? 'Copied' : 'Copy Command'}
+                  {copiedCommand === key.api_key ? 'Copied' : 'Copy'}
                 </button>
                 <button 
                   className="delete-button"

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -100,12 +100,27 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
     }
   };
 
+  const getBackendUrl = () => {
+    // Get backend URL from environment variable set by deployment
+    return (window as any).__BACKEND_URL__ || process.env.BACKEND_URL || 'https://simple-relay-staging-573916960175.us-central1.run.app';
+  };
+
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
       onMessage('API key copied to clipboard');
     } catch (error) {
       onMessage('Failed to copy to clipboard');
+    }
+  };
+
+  const copyCommand = async (apiKey: string) => {
+    const command = `ANTHROPIC_AUTH_TOKEN=${apiKey} ANTHROPIC_BASE_URL=${getBackendUrl()} claude`;
+    try {
+      await navigator.clipboard.writeText(command);
+      onMessage('Command copied to clipboard');
+    } catch (error) {
+      onMessage('Failed to copy command');
     }
   };
 
@@ -144,13 +159,24 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
                 <span className="key-date">
                   Created {new Date(key.created_at).toLocaleDateString('en-CA')}
                 </span>
+                <div className="key-command">
+                  <code>
+                    ANTHROPIC_AUTH_TOKEN={key.api_key} ANTHROPIC_BASE_URL={getBackendUrl()} claude
+                  </code>
+                </div>
               </div>
               <div className="key-actions">
                 <button 
                   className="copy-button"
                   onClick={() => copyToClipboard(key.api_key)}
                 >
-                  Copy
+                  Copy Key
+                </button>
+                <button 
+                  className="copy-command-button"
+                  onClick={() => copyCommand(key.api_key)}
+                >
+                  Copy Command
                 </button>
                 <button 
                   className="delete-button"

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -147,7 +147,7 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
 
       {apiKeys.length === 0 ? (
         <div className="no-keys">
-          {!apiEnabled ? 'API access is not enabled. Please contact us to enable access.' : 'Create your first key to get started.'}
+          {!apiEnabled ? 'API access disabled. Contact us to get access.' : 'Create your first key to get started.'}
         </div>
       ) : (
         <div className="key-list">

--- a/apps/frontend/src/components/ApiKeyTable.tsx
+++ b/apps/frontend/src/components/ApiKeyTable.tsx
@@ -104,8 +104,11 @@ export default function ApiKeyTable({ userEmail, onMessage }: ApiKeyTableProps) 
   };
 
   const getBackendUrl = () => {
-    // Get backend URL from environment variable set by deployment
-    return (window as any).__BACKEND_URL__ || process.env.BACKEND_URL || 'https://simple-relay-staging-573916960175.us-central1.run.app';
+    const backendUrl = import.meta.env.VITE_BACKEND_URL;
+    if (!backendUrl) {
+      throw new Error('VITE_BACKEND_URL environment variable is required');
+    }
+    return backendUrl;
   };
 
   const copyCommand = async (apiKey: string) => {

--- a/apps/frontend/src/components/Dashboard.tsx
+++ b/apps/frontend/src/components/Dashboard.tsx
@@ -47,7 +47,7 @@ export default function Dashboard({ userEmail, onMessage }: DashboardProps) {
         <div className="main-panel-content">
           <div className="api-keys-section">
             <h2>API Keys</h2>
-            <p className="description">Manage your API keys for accessing AI Fastlane services.</p>
+            <p className="description">Manage your API keys for accessing the service.</p>
             
             <ApiKeyTable userEmail={userEmail} onMessage={onMessage} />
           </div>

--- a/scripts/grant-api-access.sh
+++ b/scripts/grant-api-access.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Grant API Access Script for Firestore
+# This script enables API access for a specific user by setting api_enabled to true
+# Updates user documents in the users collection
+
+set -e  # Exit on any error
+
+# Default values
+EMAIL=""
+PROJECT_ID=""
+DATABASE=""
+REVOKE=false
+
+# Function to show usage
+show_usage() {
+    echo "Grant API Access Script"
+    echo ""
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  -e, --email EMAIL              User email address (required)"
+    echo "  -p, --project PROJECT_ID       GCP Project ID (required)"
+    echo "  -d, --database DATABASE        Database name (required)"
+    echo "  -r, --revoke                   Revoke API access instead of granting"
+    echo "  -h, --help                     Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  # Grant API access"
+    echo "  $0 -e user@example.com -p simple-relay-468808 -d simple-relay-db-staging"
+    echo ""
+    echo "  # Revoke API access"
+    echo "  $0 -e user@example.com -p simple-relay-468808 -d simple-relay-db-staging -r"
+    echo ""
+    echo "  # Grant API access in production"
+    echo "  $0 -e user@example.com -p simple-relay-468808 -d simple-relay-db-production"
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -e|--email)
+            EMAIL="$2"
+            shift 2
+            ;;
+        -p|--project)
+            PROJECT_ID="$2"
+            shift 2
+            ;;
+        -d|--database)
+            DATABASE="$2"
+            shift 2
+            ;;
+        -r|--revoke)
+            REVOKE=true
+            shift
+            ;;
+        -h|--help)
+            show_usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_usage
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [ -z "$EMAIL" ]; then
+    echo "❌ Error: User email is required. Use -e/--email to specify."
+    exit 1
+fi
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "❌ Error: Project ID is required. Use -p/--project to specify."
+    exit 1
+fi
+
+if [ -z "$DATABASE" ]; then
+    echo "❌ Error: Database name is required. Use -d/--database to specify."
+    exit 1
+fi
+
+# Set action based on revoke flag
+if [ "$REVOKE" = true ]; then
+    ACTION="Revoking"
+    API_ENABLED="false"
+else
+    ACTION="Granting"
+    API_ENABLED="true"
+fi
+
+echo "🚀 $ACTION API access via Firestore REST API..."
+echo "Project ID: $PROJECT_ID"
+echo "Database: $DATABASE"
+echo "User Email: $EMAIL"
+echo "API Enabled: $API_ENABLED"
+echo ""
+
+# Get access token using gcloud
+echo "🔑 Getting access token..."
+ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
+
+if [ -z "$ACCESS_TOKEN" ]; then
+    echo "❌ Failed to get access token"
+    echo "Please run: gcloud auth application-default login"
+    exit 1
+fi
+
+# Check if user exists first
+echo "🔍 Checking if user exists..."
+FIRESTORE_GET_URL="https://firestore.googleapis.com/v1/projects/$PROJECT_ID/databases/$DATABASE/documents/users/$EMAIL"
+
+USER_EXISTS=$(curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+                   -H "Content-Type: application/json" \
+                   "$FIRESTORE_GET_URL" | jq -r '.name // empty')
+
+if [ -z "$USER_EXISTS" ]; then
+    echo "❌ Error: User $EMAIL not found in database"
+    echo "Please ensure the user has an account first"
+    exit 1
+fi
+
+echo "✅ User found in database"
+
+# Update the user document to set api_enabled field
+echo "📝 Updating user API access..."
+FIRESTORE_PATCH_URL="https://firestore.googleapis.com/v1/projects/$PROJECT_ID/databases/$DATABASE/documents/users/$EMAIL?updateMask.fieldPaths=api_enabled"
+
+RESPONSE=$(curl -s -X PATCH \
+  "$FIRESTORE_PATCH_URL" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"fields\": {
+      \"api_enabled\": {
+        \"booleanValue\": $API_ENABLED
+      }
+    }
+  }")
+
+# Check if the update was successful
+if echo "$RESPONSE" | jq -e '.updateTime' > /dev/null; then
+    UPDATE_TIME=$(echo "$RESPONSE" | jq -r '.updateTime')
+    echo "✅ API access successfully updated!"
+    echo "📅 Update time: $UPDATE_TIME"
+    
+    # Show current user status
+    echo ""
+    echo "📊 User Status:"
+    echo "   Email: $EMAIL"
+    echo "   API Enabled: $API_ENABLED"
+    
+    if [ "$REVOKE" = true ]; then
+        echo ""
+        echo "⚠️  API access has been revoked for $EMAIL"
+        echo "   The user can no longer create new API keys"
+        echo "   Existing API keys will continue to work"
+    else
+        echo ""
+        echo "🎉 API access has been granted to $EMAIL"
+        echo "   The user can now create and use API keys"
+    fi
+else
+    echo "❌ Failed to update user API access"
+    echo "Response: $RESPONSE"
+    exit 1
+fi
+
+echo ""
+echo "✅ Operation completed successfully!"

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -299,6 +299,11 @@ resource "google_cloud_run_v2_service" "simple_frontend" {
         value = var.cookie_secret
       }
 
+      env {
+        name  = "BACKEND_URL"
+        value = var.backend_url
+      }
+
       ports {
         container_port = 3000
       }

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -299,10 +299,6 @@ resource "google_cloud_run_v2_service" "simple_frontend" {
         value = var.cookie_secret
       }
 
-      env {
-        name  = "BACKEND_URL"
-        value = var.backend_url
-      }
 
       ports {
         container_port = 3000

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -76,10 +76,6 @@ resource "google_cloud_run_v2_service" "simple_relay" {
         value = var.api_secret_key
       }
 
-      env {
-        name  = "ALLOWED_CLIENT_SECRET_KEY"
-        value = var.client_secret_key
-      }
 
 
       ports {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,10 +111,6 @@ variable "cookie_secret" {
   sensitive   = true
 }
 
-variable "backend_url" {
-  description = "Backend service URL for frontend to display in API key commands"
-  type        = string
-}
 
 variable "deploy_environment" {
   description = "Environment (production or staging)"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -92,11 +92,6 @@ variable "api_secret_key" {
   sensitive   = true
 }
 
-variable "client_secret_key" {
-  description = "Client Secret Key" 
-  type        = string
-  sensitive   = true
-}
 
 variable "resend_api_key" {
   description = "Resend API Key for email service"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,6 +111,11 @@ variable "cookie_secret" {
   sensitive   = true
 }
 
+variable "backend_url" {
+  description = "Backend service URL for frontend to display in API key commands"
+  type        = string
+}
+
 variable "deploy_environment" {
   description = "Environment (production or staging)"
   type        = string


### PR DESCRIPTION
## Summary
- Implement API key lookup service with 1-minute TTL caching
- Use thread-safe HashiCorp LRU cache for better performance
- Extract user identification from API keys instead of hardcoded user ID
- Reject requests without valid API keys with 401 status
- Pass user ID through context to billing and storage services

## Test plan
- [x] API key lookup works with caching
- [x] Invalid API keys are rejected with 401
- [x] User ID flows through to billing and storage
- [x] LRU cache handles concurrent access safely