### PR TITLE
Improve points display system and internationalization

### DIFF
--- a/apps/backend/cmd/main.go
+++ b/apps/backend/cmd/main.go
@@ -192,7 +192,7 @@ func main() {
 
 			// Return 529 (overloaded) to client instead of 429
 			resp.StatusCode = 529
-			resp.Status = "529 Switching Lanes"
+			resp.Status = messages.ClientErrorMessages.TokenOverloaded
 			
 			// Clear all headers from the response
 			for key := range resp.Header {

--- a/apps/backend/internal/messages/errors.go
+++ b/apps/backend/internal/messages/errors.go
@@ -5,8 +5,10 @@ var ClientErrorMessages = struct {
 	Unauthorized        string
 	InternalServerError string
 	DailyLimitExceeded  string
+	TokenOverloaded     string
 }{
 	Unauthorized:        "[AFL] Unauthorized",
 	InternalServerError: "[AFL] Internal Server Error",
 	DailyLimitExceeded:  "[AFL] Reached daily limit. Resets at 4am UTC+8.",
+	TokenOverloaded:     "[AFL] Token overloaded",
 }

--- a/apps/frontend/src/components/UsageStats.tsx
+++ b/apps/frontend/src/components/UsageStats.tsx
@@ -178,10 +178,10 @@ export default function UsageStats({ userEmail, onMessage }: UsageStatsProps) {
                   {/* Stats */}
                   <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '14px', color: '#333', marginBottom: '8px' }}>
                     <span>
-                      {Math.floor(costLimitInfo.costLimit * 100)} {t('usage.points', 'Points')}
+                      {Math.floor(costLimitInfo.costLimit * 1000)} {t('usage.points', 'Points')}
                     </span>
                     <span style={{ color: costLimitInfo.remaining < 0 ? '#dc3545' : (costLimitInfo.remaining / costLimitInfo.costLimit < 0.2) ? '#dc3545' : '#28a745', fontWeight: '600' }}>
-                      {costLimitInfo.remaining >= 0 ? `${Math.ceil(costLimitInfo.remaining * 100)} ${t('usage.remaining', 'remaining')}` : `${Math.ceil(costLimitInfo.remaining * 100)}`}
+                      {costLimitInfo.remaining >= 0 ? `${Math.ceil(costLimitInfo.remaining * 1000)} ${t('usage.remaining', 'remaining')}` : `${Math.ceil(costLimitInfo.remaining * 1000)}`}
                     </span>
                   </div>
                   
@@ -215,7 +215,7 @@ export default function UsageStats({ userEmail, onMessage }: UsageStatsProps) {
           <table className="usage-table">
             <thead>
               <tr>
-                <th>Date</th>
+                <th>{t('usage.date')}</th>
                 <th>{t('usage.model')}</th>
                 <th>{t('usage.requests')}</th>
                 <th>{t('usage.input')}</th>
@@ -262,7 +262,7 @@ export default function UsageStats({ userEmail, onMessage }: UsageStatsProps) {
                   <td className="stats-cell">
                     {Object.entries(group.models).map(([modelName, modelStats], index) => (
                       <span key={modelName}>
-                        {(modelStats.totalCost * 100).toFixed(2)}
+                        {Math.ceil(modelStats.totalCost * 1000)}
                         {index < Object.entries(group.models).length - 1 && <br />}
                       </span>
                     ))}

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "title": "AI Fastlane",
-    "tagline": "Never fall behind."
+    "tagline": "Fast and simple."
   },
   "auth": {
     "verify": "Verify",
@@ -11,7 +11,7 @@
     "backToSignIn": "← Back to Sign In",
     "signOut": "Sign Out",
     "signedInAs": "Signed in as",
-    "tagline": "Never fall behind in the AI revolution",
+    "tagline": "Fast and simple",
     "emailPlaceholder": "Enter your email",
     "continue": "Continue",
     "sending": "Sending...",

--- a/apps/frontend/src/i18n/locales/zh.json
+++ b/apps/frontend/src/i18n/locales/zh.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "title": "AI快线",
-    "tagline": "快人一步"
+    "tagline": "简单快捷"
   },
   "auth": {
     "verify": "验证",
@@ -11,7 +11,7 @@
     "backToSignIn": "← 返回登录",
     "signOut": "退出登录",
     "signedInAs": "当前登录",
-    "tagline": "快人一步",
+    "tagline": "简单快捷",
     "emailPlaceholder": "请输入您的邮箱",
     "continue": "继续",
     "sending": "发送中...",

--- a/apps/frontend/src/i18n/locales/zh.json
+++ b/apps/frontend/src/i18n/locales/zh.json
@@ -68,7 +68,7 @@
   },
   "usage": {
     "title": "使用统计",
-    "description": "免费账户每日限额5积分",
+    "description": "免费账户每日限额50积分",
     "hour": "小时",
     "model": "模型",
     "requests": "请求数",


### PR DESCRIPTION
## Summary
- Scale points calculation from *100 to *1000 for better user experience  
- Display consumed points as ceiling integers instead of decimals
- Add i18n support for Date column header and update Chinese translations

## Changes Made

### Points System Improvements
- **Points Display**: Changed from `cost * 100` to `cost * 1000` 
- **Usage Table**: Show ceiling integers using `Math.ceil()` instead of decimals
- **Cost Limits**: $0.05 limit now displays as "50 Points" instead of "5 Points"

### Internationalization Improvements
- **Date Header**: Added i18n support for "Date" column in usage table
- **Chinese Updates**: Updated daily limit text from "5积分" to "50积分"

## Test Plan
- [ ] Verify points display shows larger, more intuitive numbers
- [ ] Check usage table shows whole numbers without decimals  
- [ ] Test Chinese language shows "日期" for Date column
- [ ] Confirm daily limit shows as "50积分" in Chinese

🤖 Generated with [Claude Code](https://claude.ai/code)