### PR TITLE
Make default API access configurable via app_config

### DIFF
--- a/apps/frontend/services/user-database.ts
+++ b/apps/frontend/services/user-database.ts
@@ -1,5 +1,6 @@
 import { Firestore } from '@google-cloud/firestore';
 import { PointsLimitDatabase } from './points-limit-database.js';
+import { ConfigService } from './config.js';
 
 export interface User {
   email: string;                    // Primary key
@@ -30,10 +31,13 @@ class FirestoreUserDatabase {
   }
 
   async create(user: Omit<User, 'created_at' | 'api_enabled'>): Promise<User> {
+    // Get default API access setting from config, fallback to false
+    const defaultApiEnabled = await ConfigService.getConfig('default_api_enabled') ?? false;
+    
     const newUser: User = {
       ...user,
       created_at: new Date(),
-      api_enabled: true,
+      api_enabled: Boolean(defaultApiEnabled),
     };
     
     // Create user document


### PR DESCRIPTION
## Summary
- Changed hardcoded `api_enabled: true` to use configurable value from `default_api_enabled` config
- Added secure fallback to `false` if config is not set
- Enables administrators to control new user API access via config manager script
- Provides flexible API access policies without requiring code changes

## Test plan
- [ ] Verify new users get API access based on config setting
- [ ] Test config manager script to set `default_api_enabled` to false/true
- [ ] Confirm fallback to false works when config doesn't exist
- [ ] Validate existing users are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)