### PR TITLE
Make default daily points limit configurable

### DIFF
--- a/apps/frontend/server/index.ts
+++ b/apps/frontend/server/index.ts
@@ -100,18 +100,23 @@ app.post('/api/signin', ipRateLimit, validateSignIn, async (req, res) => {
   const verificationCode = generateVerificationCode();
   const verificationExpiresAt = new Date(Date.now() + 10 * 60 * 1000);
 
-  if (existingUser) {
-    await UserDatabase.updateUser(email, {
-      verification_token: verificationCode,
-      verification_expires_at: verificationExpiresAt
-    });
-  } else {
-    await UserDatabase.create({
-      email,
-      last_login: null,
-      verification_token: verificationCode,
-      verification_expires_at: verificationExpiresAt
-    });
+  try {
+    if (existingUser) {
+      await UserDatabase.updateUser(email, {
+        verification_token: verificationCode,
+        verification_expires_at: verificationExpiresAt
+      });
+    } else {
+      await UserDatabase.create({
+        email,
+        last_login: null,
+        verification_token: verificationCode,
+        verification_expires_at: verificationExpiresAt
+      });
+    }
+  } catch (error) {
+    console.error('Error creating/updating user:', error);
+    return res.status(500).json({ error: 'Failed to process user registration' });
   }
 
   try {

--- a/apps/frontend/services/user-database.ts
+++ b/apps/frontend/services/user-database.ts
@@ -34,6 +34,15 @@ class FirestoreUserDatabase {
     // Get default API access setting from config, fallback to false
     const defaultApiEnabled = await ConfigService.getConfig('default_api_enabled') ?? false;
     
+    // Get default daily points limit from config (required)
+    const defaultDailyPointsLimit = await ConfigService.getConfig('default_daily_points_limit');
+    if (defaultDailyPointsLimit === null || defaultDailyPointsLimit === undefined) {
+      throw new Error('default_daily_points_limit configuration is not set');
+    }
+    if (typeof defaultDailyPointsLimit !== 'number' || defaultDailyPointsLimit <= 0) {
+      throw new Error(`default_daily_points_limit must be a positive number, got: ${defaultDailyPointsLimit}`);
+    }
+    
     const newUser: User = {
       ...user,
       created_at: new Date(),
@@ -50,8 +59,8 @@ class FirestoreUserDatabase {
       api_enabled: newUser.api_enabled,
     });
     
-    // Set initial points limit of 500 for new users
-    await PointsLimitDatabase.setPointsLimit(user.email, 500);
+    // Set initial points limit for new users from config
+    await PointsLimitDatabase.setPointsLimit(user.email, defaultDailyPointsLimit);
     
     return newUser;
   }


### PR DESCRIPTION
## Summary
- Added `default_daily_points_limit` configuration parameter to control initial points limit for new users
- Updated user creation logic to read from config without hardcoded fallback
- Added proper error handling when config value is missing

## Changes
- Modified `UserDatabase.create()` to read points limit from config service
- Throws error if `default_daily_points_limit` config is not set or invalid
- Added try-catch block in signin endpoint to handle user creation errors
- Config has been set to 500 in both staging and production databases

## Test plan
- [x] Verify existing users can still sign in
- [ ] Test new user registration with config value set
- [ ] Test error handling when config value is missing
- [ ] Verify proper error message is returned to client on configuration errors

🤖 Generated with [Claude Code](https://claude.ai/code)