### PR TITLE
Fix Claude model pricing configuration

### DIFF
--- a/apps/billing/internal/services/points_conversion.go
+++ b/apps/billing/internal/services/points_conversion.go
@@ -1,8 +1,10 @@
 package services
 
+import "math"
+
 // ConvertCostToPoints 将成本转换为积分
-// 当前实现：积分 = 成本 * 10000
+// 当前实现：积分 = 成本 * 10000 (使用四舍五入)
 // 此转换逻辑可能在未来发生变化，因此提取到单独的文件中
 func ConvertCostToPoints(cost float64) int {
-	return int(cost * 10000)
+	return int(math.Round(cost * 10000))
 }


### PR DESCRIPTION
## Summary
- Fixed pricing for Claude 4 models (Opus 4.1, Sonnet 4) 
- Updated Haiku 3.5 pricing to reflect December 2024 price reduction
- Simplified pricing fallback logic

## Changes
- Added `claude-opus-4-1-20250805` with correct Opus pricing ($15/$75)
- Added `claude-sonnet-4-20250514` with Sonnet pricing ($3/$15)
- Updated Haiku 3.5 pricing from $1/$5 to $0.80/$4 per million tokens
- Simplified fallback logic to use pattern matching (opus/sonnet/haiku)
- Removed unused functions that were not referenced anywhere
- Added error logging when unknown models fall back to default pricing

## Test Plan
The pricing changes will be validated in staging by checking:
- [ ] Opus 4.1 models are charged at $15/$75 rates
- [ ] Haiku 3.5 models reflect the new $0.80/$4 pricing
- [ ] Unknown models log errors and fall back to Sonnet pricing

🤖 Generated with Claude Code